### PR TITLE
Do not spam known_hosts

### DIFF
--- a/anaconda_tamer.sh
+++ b/anaconda_tamer.sh
@@ -12,4 +12,4 @@ else
 fi
 
 
-ssh -t -o StrictHostKeyChecking=no "root@$HOST" "tmux attach-session -d -t anaconda"
+ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "root@$HOST" "tmux attach-session -d -t anaconda"


### PR DESCRIPTION
Connecting to temporary/disposable hosts should not spam
the ~/.ssh/known_hosts file.